### PR TITLE
ci: ship nightly drift checks, flake tracking, failure triage, and RC smoke

### DIFF
--- a/.github/scripts/apply_branch_protection.sh
+++ b/.github/scripts/apply_branch_protection.sh
@@ -25,6 +25,7 @@ cat >"$payload_file" <<JSON
       "CI / test",
       "CI / staticcheck",
       "CI / openapi-contract",
+      "CI / config-lint",
       "CI / docker-build",
       "CI / helm-lint",
       "CI / security-gosec",

--- a/.github/scripts/apply_branch_protection.sh
+++ b/.github/scripts/apply_branch_protection.sh
@@ -21,19 +21,19 @@ cat >"$payload_file" <<JSON
 {
   "required_status_checks": {
     "strict": true,
-    "contexts": [
-      "CI / test",
-      "CI / staticcheck",
-      "CI / openapi-contract",
-      "CI / config-lint",
-      "CI / docker-build",
-      "CI / helm-lint",
-      "CI / security-gosec",
-      "CI / security-govulncheck",
-      "CI / security-trivy",
-      "CI / security-sbom",
-      "CI / perf-smoke",
-      "CI / integration"
+    "checks": [
+      {"context": "test", "app_id": 15368},
+      {"context": "staticcheck", "app_id": 15368},
+      {"context": "openapi-contract", "app_id": 15368},
+      {"context": "config-lint", "app_id": 15368},
+      {"context": "docker-build", "app_id": 15368},
+      {"context": "helm-lint", "app_id": 15368},
+      {"context": "security-gosec", "app_id": 15368},
+      {"context": "security-govulncheck", "app_id": 15368},
+      {"context": "security-trivy", "app_id": 15368},
+      {"context": "security-sbom", "app_id": 15368},
+      {"context": "perf-smoke", "app_id": 15368},
+      {"context": "integration", "app_id": 15368}
     ]
   },
   "enforce_admins": true,

--- a/.github/scripts/collect_flake_metrics.sh
+++ b/.github/scripts/collect_flake_metrics.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+require_bin() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing dependency: $1" >&2
+    exit 1
+  fi
+}
+
+require_bin gh
+require_bin jq
+
+if [[ -z "${GH_TOKEN:-}" ]]; then
+  echo "GH_TOKEN is required" >&2
+  exit 1
+fi
+if [[ -z "${REPO:-}" ]]; then
+  echo "REPO is required (owner/repo)" >&2
+  exit 1
+fi
+if [[ -z "${RUN_ID:-}" ]]; then
+  echo "RUN_ID is required" >&2
+  exit 1
+fi
+
+output_dir="${OUTPUT_DIR:-flake-metrics}"
+workflow_file="${WORKFLOW_FILE:-ci.yml}"
+branch="${BRANCH:-main}"
+trend_limit="${TREND_RUN_LIMIT:-30}"
+
+mkdir -p "${output_dir}"
+
+jobs_file="$(mktemp)"
+runs_file="$(mktemp)"
+trap 'rm -f "${jobs_file}" "${runs_file}"' EXIT
+
+# Current run snapshot for integration/perf-smoke status and timing.
+gh api "repos/${REPO}/actions/runs/${RUN_ID}/jobs?per_page=100" >"${jobs_file}"
+
+jq -n \
+  --arg generated_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --arg repo "${REPO}" \
+  --argjson run_id "${RUN_ID}" \
+  --arg run_url "https://github.com/${REPO}/actions/runs/${RUN_ID}" \
+  --slurpfile jobs "${jobs_file}" \
+  '{
+    generated_at: $generated_at,
+    repository: $repo,
+    run_id: $run_id,
+    run_url: $run_url,
+    jobs: ($jobs[0].jobs
+      | map(select(.name == "integration" or .name == "perf-smoke")
+      | {
+          name: .name,
+          status: .status,
+          conclusion: .conclusion,
+          started_at: .started_at,
+          completed_at: .completed_at,
+          duration_seconds: (if (.started_at != null and .completed_at != null)
+            then ((.completed_at | fromdateiso8601) - (.started_at | fromdateiso8601))
+            else null
+          end)
+        }))
+  }' >"${output_dir}/current.json"
+
+printf 'run_id,run_number,run_created_at,run_conclusion,run_url,job_name,job_conclusion,job_started_at,job_completed_at,duration_seconds\n' >"${output_dir}/trend.csv"
+
+# Trend window over recent CI runs on main.
+gh api "repos/${REPO}/actions/workflows/${workflow_file}/runs?branch=${branch}&per_page=${trend_limit}" >"${runs_file}"
+
+while IFS=$'\t' read -r run_id run_number run_created_at run_conclusion run_url; do
+  run_jobs_file="$(mktemp)"
+  gh api "repos/${REPO}/actions/runs/${run_id}/jobs?per_page=100" >"${run_jobs_file}"
+
+  jq -r \
+    --arg run_id "${run_id}" \
+    --arg run_number "${run_number}" \
+    --arg run_created_at "${run_created_at}" \
+    --arg run_conclusion "${run_conclusion}" \
+    --arg run_url "${run_url}" \
+    '.jobs[]
+      | select(.name == "integration" or .name == "perf-smoke")
+      | [
+          $run_id,
+          $run_number,
+          $run_created_at,
+          $run_conclusion,
+          $run_url,
+          .name,
+          (.conclusion // "unknown"),
+          (.started_at // ""),
+          (.completed_at // ""),
+          (if (.started_at != null and .completed_at != null)
+            then (((.completed_at | fromdateiso8601) - (.started_at | fromdateiso8601)) | tostring)
+            else ""
+          end)
+        ]
+      | @csv' "${run_jobs_file}" >>"${output_dir}/trend.csv"
+
+  rm -f "${run_jobs_file}"
+done < <(jq -r '.workflow_runs[] | [.id, .run_number, .created_at, .conclusion, .html_url] | @tsv' "${runs_file}")
+
+jq -n \
+  --arg generated_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --arg repo "${REPO}" \
+  --arg branch "${branch}" \
+  --argjson run_id "${RUN_ID}" \
+  --arg workflow_file "${workflow_file}" \
+  --arg trend_csv "${output_dir}/trend.csv" \
+  --arg current_json "${output_dir}/current.json" \
+  '{
+    generated_at: $generated_at,
+    repository: $repo,
+    branch: $branch,
+    source_run_id: $run_id,
+    workflow_file: $workflow_file,
+    artifacts: {
+      current: $current_json,
+      trend: $trend_csv
+    }
+  }' >"${output_dir}/manifest.json"
+
+echo "Flake metrics written to ${output_dir}"

--- a/.github/scripts/create_ci_failure_issue.sh
+++ b/.github/scripts/create_ci_failure_issue.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+require_bin() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing dependency: $1" >&2
+    exit 1
+  fi
+}
+
+require_bin gh
+require_bin jq
+
+if [[ -z "${GH_TOKEN:-}" ]]; then
+  echo "GH_TOKEN is required" >&2
+  exit 1
+fi
+if [[ -z "${REPO:-}" ]]; then
+  echo "REPO is required (owner/repo)" >&2
+  exit 1
+fi
+if [[ -z "${RUN_ID:-}" ]]; then
+  echo "RUN_ID is required" >&2
+  exit 1
+fi
+
+run_file="$(mktemp)"
+jobs_file="$(mktemp)"
+failed_file="$(mktemp)"
+body_file="$(mktemp)"
+work_dir="$(mktemp -d)"
+trap 'rm -f "${run_file}" "${jobs_file}" "${failed_file}" "${body_file}"; rm -rf "${work_dir}"' EXIT
+
+gh api "repos/${REPO}/actions/runs/${RUN_ID}" >"${run_file}"
+gh api "repos/${REPO}/actions/runs/${RUN_ID}/jobs?per_page=100" >"${jobs_file}"
+
+jq -r '.jobs[] | select(.conclusion == "failure") | [.id, .name, .html_url] | @tsv' "${jobs_file}" >"${failed_file}"
+
+if [[ ! -s "${failed_file}" ]]; then
+  echo "No failed jobs found for run ${RUN_ID}; skipping issue creation"
+  exit 0
+fi
+
+title="CI failure on main: run ${RUN_ID}"
+existing_issue="$(gh issue list -R "${REPO}" --state open --search "\"${title}\" in:title" --json number --jq '.[0].number // empty')"
+if [[ -n "${existing_issue}" ]]; then
+  echo "Issue #${existing_issue} already exists for run ${RUN_ID}; skipping"
+  exit 0
+fi
+
+# Ensure label exists for triage routing.
+gh label create ci-failure -R "${REPO}" --description "Automated CI failure reports on main" --color B60205 2>/dev/null || true
+
+run_url="$(jq -r '.html_url' "${run_file}")"
+head_sha="$(jq -r '.head_sha' "${run_file}")"
+run_attempt="$(jq -r '.run_attempt' "${run_file}")"
+created_at="$(jq -r '.created_at' "${run_file}")"
+
+{
+  echo "Automated CI failure report for a \\`main\\` push run."
+  echo
+  echo "- Run: ${run_url}"
+  echo "- Run ID: ${RUN_ID}"
+  echo "- Attempt: ${run_attempt}"
+  echo "- Head SHA: \\`${head_sha}\\`"
+  echo "- Created At: ${created_at}"
+  echo
+  echo "## Failed Jobs"
+  while IFS=$'\t' read -r job_id job_name job_url; do
+    echo "- [${job_name}](${job_url}) (job id: ${job_id})"
+  done <"${failed_file}"
+} >"${body_file}"
+
+while IFS=$'\t' read -r job_id job_name _job_url; do
+  log_file="${work_dir}/job-${job_id}.log"
+  if ! gh run view "${RUN_ID}" -R "${REPO}" --job "${job_id}" --log-failed >"${log_file}" 2>/dev/null; then
+    gh run view "${RUN_ID}" -R "${REPO}" --job "${job_id}" --log >"${log_file}" 2>/dev/null || true
+  fi
+
+  {
+    echo
+    echo "<details><summary>${job_name} failed log (truncated)</summary>"
+    echo
+    echo "\\`\\`\\`text"
+    if [[ -s "${log_file}" ]]; then
+      head -n 220 "${log_file}" | sed 's/\r$//'
+    else
+      echo "No log output available for job ${job_id}."
+    fi
+    echo "\\`\\`\\`"
+    echo
+    echo "</details>"
+  } >>"${body_file}"
+done <"${failed_file}"
+
+issue_url="$(gh issue create -R "${REPO}" --title "${title}" --body-file "${body_file}" --label ci-failure)"
+echo "Created CI failure issue: ${issue_url}"

--- a/.github/scripts/create_ci_failure_issue.sh
+++ b/.github/scripts/create_ci_failure_issue.sh
@@ -41,12 +41,8 @@ if [[ ! -s "${failed_file}" ]]; then
   exit 0
 fi
 
-title="CI failure on main: run ${RUN_ID}"
+title="CI failure on main"
 existing_issue="$(gh issue list -R "${REPO}" --state open --search "\"${title}\" in:title" --json number --jq '.[0].number // empty')"
-if [[ -n "${existing_issue}" ]]; then
-  echo "Issue #${existing_issue} already exists for run ${RUN_ID}; skipping"
-  exit 0
-fi
 
 # Ensure label exists for triage routing.
 gh label create ci-failure -R "${REPO}" --description "Automated CI failure reports on main" --color B60205 2>/dev/null || true
@@ -92,6 +88,12 @@ while IFS=$'\t' read -r job_id job_name _job_url; do
     echo "</details>"
   } >>"${body_file}"
 done <"${failed_file}"
+
+if [[ -n "${existing_issue}" ]]; then
+  gh issue comment "${existing_issue}" -R "${REPO}" --body-file "${body_file}" >/dev/null
+  echo "Added CI failure details to existing issue #${existing_issue}"
+  exit 0
+fi
 
 issue_url="$(gh issue create -R "${REPO}" --title "${title}" --body-file "${body_file}" --label ci-failure)"
 echo "Created CI failure issue: ${issue_url}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
     - cron: "17 9 * * *"
 
 concurrency:
-  group: ci-${{ github.ref }}
+  group: ci-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: ["main"]
   pull_request:
+  workflow_dispatch:
+  schedule:
+    # Nightly cache-bypass run to detect toolchain/cache drift.
+    - cron: "17 9 * * *"
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -12,6 +16,7 @@ concurrency:
 env:
   GOTOOLCHAIN: go1.26.1
   TOOLS_BIN: ${{ github.workspace }}/.cache/tools/bin
+  DISABLE_TOOL_CACHE: ${{ github.event_name == 'schedule' && 'true' || 'false' }}
   STATICCHECK_VERSION: v0.6.1
   GOSEC_VERSION: v2.23.0
   GOVULNCHECK_VERSION: v1.1.4
@@ -62,14 +67,21 @@ jobs:
           go-version: "1.26.1"
 
       - name: Restore tool cache
+        if: env.DISABLE_TOOL_CACHE != 'true'
         id: staticcheck-cache
         uses: actions/cache@v4
         with:
           path: ${{ env.TOOLS_BIN }}
           key: staticcheck-${{ runner.os }}-${{ env.GOTOOLCHAIN }}-${{ env.STATICCHECK_VERSION }}
 
-      - name: Install staticcheck
-        if: steps.staticcheck-cache.outputs.cache-hit != 'true'
+      - name: Install staticcheck (no cache)
+        if: env.DISABLE_TOOL_CACHE == 'true'
+        run: |
+          mkdir -p "${TOOLS_BIN}"
+          GOBIN="${TOOLS_BIN}" go install honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION}
+
+      - name: Install staticcheck (cache miss)
+        if: env.DISABLE_TOOL_CACHE != 'true' && steps.staticcheck-cache.outputs.cache-hit != 'true'
         run: |
           mkdir -p "${TOOLS_BIN}"
           GOBIN="${TOOLS_BIN}" go install honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION}
@@ -162,14 +174,21 @@ jobs:
           go-version: "1.26.1"
 
       - name: Restore tool cache
+        if: env.DISABLE_TOOL_CACHE != 'true'
         id: gosec-cache
         uses: actions/cache@v4
         with:
           path: ${{ env.TOOLS_BIN }}
           key: gosec-${{ runner.os }}-${{ env.GOTOOLCHAIN }}-${{ env.GOSEC_VERSION }}
 
-      - name: Install gosec
-        if: steps.gosec-cache.outputs.cache-hit != 'true'
+      - name: Install gosec (no cache)
+        if: env.DISABLE_TOOL_CACHE == 'true'
+        run: |
+          mkdir -p "${TOOLS_BIN}"
+          GOBIN="${TOOLS_BIN}" go install github.com/securego/gosec/v2/cmd/gosec@${GOSEC_VERSION}
+
+      - name: Install gosec (cache miss)
+        if: env.DISABLE_TOOL_CACHE != 'true' && steps.gosec-cache.outputs.cache-hit != 'true'
         run: |
           mkdir -p "${TOOLS_BIN}"
           GOBIN="${TOOLS_BIN}" go install github.com/securego/gosec/v2/cmd/gosec@${GOSEC_VERSION}
@@ -191,14 +210,21 @@ jobs:
           go-version: "1.26.1"
 
       - name: Restore tool cache
+        if: env.DISABLE_TOOL_CACHE != 'true'
         id: govulncheck-cache
         uses: actions/cache@v4
         with:
           path: ${{ env.TOOLS_BIN }}
           key: govulncheck-${{ runner.os }}-${{ env.GOTOOLCHAIN }}-${{ env.GOVULNCHECK_VERSION }}
 
-      - name: Install govulncheck
-        if: steps.govulncheck-cache.outputs.cache-hit != 'true'
+      - name: Install govulncheck (no cache)
+        if: env.DISABLE_TOOL_CACHE == 'true'
+        run: |
+          mkdir -p "${TOOLS_BIN}"
+          GOBIN="${TOOLS_BIN}" go install golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION}
+
+      - name: Install govulncheck (cache miss)
+        if: env.DISABLE_TOOL_CACHE != 'true' && steps.govulncheck-cache.outputs.cache-hit != 'true'
         run: |
           mkdir -p "${TOOLS_BIN}"
           GOBIN="${TOOLS_BIN}" go install golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION}
@@ -387,3 +413,65 @@ jobs:
         if: always()
         run: |
           docker rm -f tap-nats tap-clickhouse || true
+
+  flake-tracker:
+    if: always()
+    needs:
+      - integration
+      - perf-smoke
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Collect CI flake metrics
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          BRANCH: main
+          TREND_RUN_LIMIT: "30"
+        run: .github/scripts/collect_flake_metrics.sh
+
+      - name: Upload flake metrics artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-flake-metrics-${{ github.run_id }}
+          path: flake-metrics/
+          if-no-files-found: error
+          retention-days: 30
+
+  create-failure-issue:
+    if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/main' && contains(needs.*.result, 'failure') }}
+    needs:
+      - test
+      - staticcheck
+      - openapi-contract
+      - config-lint
+      - docker-build
+      - helm-lint
+      - security-gosec
+      - security-govulncheck
+      - security-trivy
+      - security-sbom
+      - perf-smoke
+      - integration
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Create issue with failed logs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+        run: .github/scripts/create_ci_failure_issue.sh

--- a/.github/workflows/release-candidate-smoke.yml
+++ b/.github/workflows/release-candidate-smoke.yml
@@ -1,0 +1,140 @@
+name: Release Candidate Smoke
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Git ref (branch, tag, or SHA) to validate
+        required: false
+        default: main
+      release_name:
+        description: Helm release name for smoke install
+        required: false
+        default: ensemble-tap
+      namespace:
+        description: Kubernetes namespace for smoke install
+        required: false
+        default: ensemble-rc
+
+permissions:
+  contents: read
+
+env:
+  GOTOOLCHAIN: go1.26.1
+  TAP_IMAGE_REPO: ensemble-tap
+  NATS_IMAGE: nats:2.12.4-alpine
+
+jobs:
+  rc-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.26.1"
+
+      - name: Setup Helm
+        uses: azure/setup-helm@v4
+
+      - name: Setup kind
+        uses: helm/kind-action@v1
+        with:
+          cluster_name: rc-smoke
+
+      - name: Build release-candidate image
+        env:
+          IMAGE_TAG: rc-${{ github.run_id }}-${{ github.run_attempt }}
+        run: |
+          docker build -t "${TAP_IMAGE_REPO}:${IMAGE_TAG}" .
+          echo "IMAGE_TAG=${IMAGE_TAG}" >> "$GITHUB_ENV"
+
+      - name: Load image into kind
+        run: kind load docker-image "${TAP_IMAGE_REPO}:${IMAGE_TAG}" --name rc-smoke
+
+      - name: Deploy NATS JetStream dependency
+        run: |
+          kubectl create namespace "${{ inputs.namespace }}" --dry-run=client -o yaml | kubectl apply -f -
+          cat <<MANIFEST | kubectl -n "${{ inputs.namespace }}" apply -f -
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: nats
+            labels:
+              app: nats
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                app: nats
+            template:
+              metadata:
+                labels:
+                  app: nats
+              spec:
+                containers:
+                  - name: nats
+                    image: ${NATS_IMAGE}
+                    args: ["-js"]
+                    ports:
+                      - name: client
+                        containerPort: 4222
+                      - name: monitor
+                        containerPort: 8222
+                    readinessProbe:
+                      tcpSocket:
+                        port: 4222
+                      initialDelaySeconds: 2
+                      periodSeconds: 2
+          ---
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: nats
+          spec:
+            selector:
+              app: nats
+            ports:
+              - name: client
+                port: 4222
+                targetPort: client
+              - name: monitor
+                port: 8222
+                targetPort: monitor
+          MANIFEST
+          kubectl -n "${{ inputs.namespace }}" rollout status deployment/nats --timeout=120s
+
+      - name: Deploy ensemble-tap Helm release
+        env:
+          ONBOARDING_SECRET: rc-generic-secret
+        run: |
+          helm upgrade --install "${{ inputs.release_name }}" ./charts/ensemble-tap \
+            --namespace "${{ inputs.namespace }}" \
+            --set image.repository="${TAP_IMAGE_REPO}" \
+            --set image.tag="${IMAGE_TAG}" \
+            --set config.nats.url="nats://nats:4222" \
+            --set config.providers.generic.secret="${ONBOARDING_SECRET}" \
+            --wait --timeout 180s
+
+      - name: Validate /readyz + end-to-end publish path
+        env:
+          ONBOARDING_SECRET: rc-generic-secret
+        run: |
+          ./scripts/smoke-onboarding.sh \
+            --provider generic \
+            --secret "${ONBOARDING_SECRET}" \
+            --release "${{ inputs.release_name }}" \
+            --namespace "${{ inputs.namespace }}" \
+            --local-port 18080
+
+      - name: Dump diagnostics on failure
+        if: failure()
+        run: |
+          kubectl -n "${{ inputs.namespace }}" get all
+          kubectl -n "${{ inputs.namespace }}" logs deploy/nats --tail=200 || true
+          kubectl -n "${{ inputs.namespace }}" logs deploy/${{ inputs.release_name }} --tail=200 || true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,11 +65,14 @@ This file is the operating guide for coding agents working in `ensemble-tap`.
 - `test`: `go vet` + coverage threshold (minimum `75%`).
 - `staticcheck`
 - `openapi-contract`: `TestAdminOpenAPIContractMatchesRuntime`
+- `config-lint`: runtime/chart config lint + Helm render hardening assertions
 - `docker-build`
 - `helm-lint` + `helm template`
 - `integration`: real NATS + ClickHouse integration test
 - `perf-smoke`: k6 smoke against `/livez` and `/readyz`
 - `security`: `gosec`, `govulncheck`, Trivy CRITICAL scan, SBOM generation
+- `flake-tracker`: per-run `integration`/`perf-smoke` status + duration artifact trend
+- failed `main` runs auto-open a triage issue with failed job log snippets
 
 If your change affects behavior, assume at least one of these can fail and run the relevant subset locally before committing.
 

--- a/README.md
+++ b/README.md
@@ -247,5 +247,9 @@ See chart-specific usage in `charts/ensemble-tap/README.md`.
 - CI workflow validates unit tests, static analysis (`staticcheck`), OpenAPI contract/runtime parity, Docker build, Helm chart render/lint, and real NATS+ClickHouse integration.
 - CI security gates run `gosec`, `govulncheck`, Trivy CRITICAL scan, and source SBOM generation.
 - CI performance smoke gate runs a lightweight `k6` probe against `/livez` and `/readyz`.
+- CI runs nightly (`09:17 UTC`) with tool caches disabled to catch toolchain/cache drift early.
+- CI persists flaky-job trend artifacts (`ci-flake-metrics-*`) with `integration` + `perf-smoke` status and duration history.
+- Failed `main` CI runs automatically open an issue with failed job links and log snippets for triage.
+- Run `Release Candidate Smoke` (`.github/workflows/release-candidate-smoke.yml`) before creating a `v*` tag; it deploys via Helm on `kind`, verifies `/readyz`, and validates signed webhook publish end-to-end.
 - Tag pushes matching `v*` trigger release workflow to publish multi-arch images to GHCR, generate source/image SBOMs, sign image digests with cosign keyless OIDC, and package the Helm chart.
 - Branch protection can be applied with `.github/scripts/apply_branch_protection.sh` or via the manual `Branch Protection` workflow.


### PR DESCRIPTION
## Summary\n- add nightly CI schedule that bypasses tool caches to catch toolchain/cache drift\n- add CI flake-tracker artifacts for integration/perf-smoke status + duration trends\n- auto-open a CI failure issue on main push failures with failed job log snippets\n- add release-candidate smoke workflow (kind + Helm deploy + /readyz + signed publish validation)\n- apply/update branch protection required checks script to include config-lint and security gates\n\n## Validation\n- make ci-local\n- bash -n .github/scripts/collect_flake_metrics.sh\n- bash -n .github/scripts/create_ci_failure_issue.sh\n- bash -n .github/scripts/apply_branch_protection.sh\n- local dry-run: .github/scripts/collect_flake_metrics.sh against run 22835990352\n