### PR TITLE
Use shared CI actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: evalops/service-runtime/.github/actions/setup-go-service@d348819979602be3a2b8349b5dccd41488bb7cd2
         with:
           go-version: "1.26.1"
+          download: "false"
 
       - name: Vet
         run: go vet ./...
@@ -62,9 +63,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: evalops/service-runtime/.github/actions/setup-go-service@d348819979602be3a2b8349b5dccd41488bb7cd2
         with:
           go-version: "1.26.1"
+          download: "false"
 
       - name: Restore tool cache
         if: env.DISABLE_TOOL_CACHE != 'true'
@@ -97,9 +99,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: evalops/service-runtime/.github/actions/setup-go-service@d348819979602be3a2b8349b5dccd41488bb7cd2
         with:
           go-version: "1.26.1"
+          download: "false"
 
       - name: Verify admin OpenAPI contract
         run: go test ./cmd/tap -run TestAdminOpenAPIContractMatchesRuntime -count=1
@@ -112,9 +115,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: evalops/service-runtime/.github/actions/setup-go-service@d348819979602be3a2b8349b5dccd41488bb7cd2
         with:
           go-version: "1.26.1"
+          download: "false"
 
       - name: Setup Helm
         uses: azure/setup-helm@v4
@@ -140,11 +144,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Build image
-        run: docker build .
+        uses: evalops/service-runtime/.github/actions/build-docker-image@d348819979602be3a2b8349b5dccd41488bb7cd2
+        with:
+          dockerfile: ./Dockerfile
+          tags: ensemble-tap:ci
 
   helm-lint:
     runs-on: ubuntu-latest
@@ -169,9 +173,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: evalops/service-runtime/.github/actions/setup-go-service@d348819979602be3a2b8349b5dccd41488bb7cd2
         with:
           go-version: "1.26.1"
+          download: "false"
 
       - name: Restore tool cache
         if: env.DISABLE_TOOL_CACHE != 'true'
@@ -205,9 +210,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: evalops/service-runtime/.github/actions/setup-go-service@d348819979602be3a2b8349b5dccd41488bb7cd2
         with:
           go-version: "1.26.1"
+          download: "false"
 
       - name: Restore tool cache
         if: env.DISABLE_TOOL_CACHE != 'true'
@@ -283,9 +289,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: evalops/service-runtime/.github/actions/setup-go-service@d348819979602be3a2b8349b5dccd41488bb7cd2
         with:
           go-version: "1.26.1"
+          download: "false"
 
       - name: Setup k6
         uses: grafana/setup-k6-action@v1
@@ -359,9 +366,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: evalops/service-runtime/.github/actions/setup-go-service@d348819979602be3a2b8349b5dccd41488bb7cd2
         with:
           go-version: "1.26.1"
+          download: "false"
 
       - name: Run secure NATS TLS/auth integration tests
         run: go test ./internal/publish -run 'TestNATSPublisherPublishesWith(TokenAuthOverTLS|UserPassOverTLS)' -count=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GOTOOLCHAIN: go1.26.1
+  GOTOOLCHAIN: go1.26.2
   TOOLS_BIN: ${{ github.workspace }}/.cache/tools/bin
   DISABLE_TOOL_CACHE: ${{ github.event_name == 'schedule' && 'true' || 'false' }}
   STATICCHECK_VERSION: v0.6.1
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Go
         uses: evalops/service-runtime/.github/actions/setup-go-service@d348819979602be3a2b8349b5dccd41488bb7cd2
         with:
-          go-version: "1.26.1"
+          go-version: "1.26.2"
           download: "false"
 
       - name: Vet
@@ -65,7 +65,7 @@ jobs:
       - name: Setup Go
         uses: evalops/service-runtime/.github/actions/setup-go-service@d348819979602be3a2b8349b5dccd41488bb7cd2
         with:
-          go-version: "1.26.1"
+          go-version: "1.26.2"
           download: "false"
 
       - name: Restore tool cache
@@ -101,7 +101,7 @@ jobs:
       - name: Setup Go
         uses: evalops/service-runtime/.github/actions/setup-go-service@d348819979602be3a2b8349b5dccd41488bb7cd2
         with:
-          go-version: "1.26.1"
+          go-version: "1.26.2"
           download: "false"
 
       - name: Verify admin OpenAPI contract
@@ -117,7 +117,7 @@ jobs:
       - name: Setup Go
         uses: evalops/service-runtime/.github/actions/setup-go-service@d348819979602be3a2b8349b5dccd41488bb7cd2
         with:
-          go-version: "1.26.1"
+          go-version: "1.26.2"
           download: "false"
 
       - name: Setup Helm
@@ -175,7 +175,7 @@ jobs:
       - name: Setup Go
         uses: evalops/service-runtime/.github/actions/setup-go-service@d348819979602be3a2b8349b5dccd41488bb7cd2
         with:
-          go-version: "1.26.1"
+          go-version: "1.26.2"
           download: "false"
 
       - name: Restore tool cache
@@ -212,7 +212,7 @@ jobs:
       - name: Setup Go
         uses: evalops/service-runtime/.github/actions/setup-go-service@d348819979602be3a2b8349b5dccd41488bb7cd2
         with:
-          go-version: "1.26.1"
+          go-version: "1.26.2"
           download: "false"
 
       - name: Restore tool cache
@@ -250,7 +250,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Trivy filesystem scan
-        uses: aquasecurity/trivy-action@0.34.2
+        uses: aquasecurity/trivy-action@v0.35.0
         with:
           scan-type: fs
           scan-ref: .
@@ -291,7 +291,7 @@ jobs:
       - name: Setup Go
         uses: evalops/service-runtime/.github/actions/setup-go-service@d348819979602be3a2b8349b5dccd41488bb7cd2
         with:
-          go-version: "1.26.1"
+          go-version: "1.26.2"
           download: "false"
 
       - name: Setup k6
@@ -368,7 +368,7 @@ jobs:
       - name: Setup Go
         uses: evalops/service-runtime/.github/actions/setup-go-service@d348819979602be3a2b8349b5dccd41488bb7cd2
         with:
-          go-version: "1.26.1"
+          go-version: "1.26.2"
           download: "false"
 
       - name: Run secure NATS TLS/auth integration tests

--- a/.github/workflows/release-candidate-smoke.yml
+++ b/.github/workflows/release-candidate-smoke.yml
@@ -20,7 +20,7 @@ permissions:
   contents: read
 
 env:
-  GOTOOLCHAIN: go1.26.1
+  GOTOOLCHAIN: go1.26.2
   TAP_IMAGE_REPO: ensemble-tap
   NATS_IMAGE: nats:2.12.4-alpine
 
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Go
         uses: evalops/service-runtime/.github/actions/setup-go-service@d348819979602be3a2b8349b5dccd41488bb7cd2
         with:
-          go-version: "1.26.1"
+          go-version: "1.26.2"
           download: "false"
 
       - name: Setup Helm

--- a/.github/workflows/release-candidate-smoke.yml
+++ b/.github/workflows/release-candidate-smoke.yml
@@ -35,9 +35,10 @@ jobs:
           ref: ${{ inputs.ref }}
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: evalops/service-runtime/.github/actions/setup-go-service@d348819979602be3a2b8349b5dccd41488bb7cd2
         with:
           go-version: "1.26.1"
+          download: "false"
 
       - name: Setup Helm
         uses: azure/setup-helm@v4
@@ -47,12 +48,15 @@ jobs:
         with:
           cluster_name: rc-smoke
 
+      - name: Set image tag
+        run: echo "IMAGE_TAG=rc-${{ github.run_id }}-${{ github.run_attempt }}" >> "$GITHUB_ENV"
+
       - name: Build release-candidate image
-        env:
-          IMAGE_TAG: rc-${{ github.run_id }}-${{ github.run_attempt }}
-        run: |
-          docker build -t "${TAP_IMAGE_REPO}:${IMAGE_TAG}" .
-          echo "IMAGE_TAG=${IMAGE_TAG}" >> "$GITHUB_ENV"
+        uses: evalops/service-runtime/.github/actions/build-docker-image@d348819979602be3a2b8349b5dccd41488bb7cd2
+        with:
+          dockerfile: ./Dockerfile
+          tags: ${{ env.TAP_IMAGE_REPO }}:${{ env.IMAGE_TAG }}
+          load: "true"
 
       - name: Load image into kind
         run: kind load docker-image "${TAP_IMAGE_REPO}:${IMAGE_TAG}" --name rc-smoke

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,44 +19,28 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: evalops/service-runtime/.github/actions/setup-go-service@d348819979602be3a2b8349b5dccd41488bb7cd2
         with:
-          go-version-file: go.mod
+          go-version: "1.26.1"
+          download: "false"
 
       - name: Test
         run: go test ./...
 
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Setup Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Docker metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ghcr.io/${{ github.repository }}
-          tags: |
-            type=ref,event=tag
-            type=sha,prefix=sha-
-
       - name: Build and push image
         id: build
-        uses: docker/build-push-action@v6
+        uses: evalops/service-runtime/.github/actions/publish-ghcr-image@d348819979602be3a2b8349b5dccd41488bb7cd2
         with:
-          context: .
-          push: true
+          image_name: ghcr.io/${{ github.repository }}
+          github_actor: ${{ github.actor }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          dockerfile: ./Dockerfile
           platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          setup_qemu: "true"
+          push: "true"
+          metadata_tags: |
+            type=ref,event=tag
+            type=sha,prefix=sha-
 
       - name: Prepare dist directory
         run: mkdir -p dist
@@ -121,7 +105,7 @@ jobs:
             dist/image-sbom.spdx.json
           body: |
             Container images:
-            ${{ steps.meta.outputs.tags }}
+            ${{ steps.build.outputs.tags }}
 
             Digest:
             ${{ steps.build.outputs.digest }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Go
         uses: evalops/service-runtime/.github/actions/setup-go-service@d348819979602be3a2b8349b5dccd41488bb7cd2
         with:
-          go-version: "1.26.1"
+          go-version: "1.26.2"
           download: "false"
 
       - name: Test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ This file is the operating guide for coding agents working in `ensemble-tap`.
 
 ## 4. Toolchain and Baseline Commands
 
-- Go toolchain: as defined in CI (`go1.26.1` via `GOTOOLCHAIN`).
+- Go toolchain: as defined in CI (`go1.26.2` via `GOTOOLCHAIN`).
 - Core local commands:
   - `go test ./...`
   - `go test -race ./...`

--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,10 @@ vet:
 	$(GO) vet ./...
 
 staticcheck-install:
-	GOTOOLCHAIN=go1.26.1 $(GO) install honnef.co/go/tools/cmd/staticcheck@$(STATICCHECK_VERSION)
+	GOTOOLCHAIN=go1.26.2 $(GO) install honnef.co/go/tools/cmd/staticcheck@$(STATICCHECK_VERSION)
 
 staticcheck: staticcheck-install
-	GOTOOLCHAIN=go1.26.1 $(STATICCHECK_BIN) ./...
+	GOTOOLCHAIN=go1.26.2 $(STATICCHECK_BIN) ./...
 
 coverage:
 	$(GO) test ./... -coverprofile=/tmp/ensemble-tap.coverage.out


### PR DESCRIPTION
## Summary
- switch ensemble-tap workflow Go setup to the shared setup-go-service action
- move smoke and release image builds onto the shared Docker build/publish actions
- bump the repo CI and local staticcheck toolchain from Go 1.26.1 to 1.26.2 and refresh Trivy to the current action tag

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); YAML.load_file(".github/workflows/release-candidate-smoke.yml"); YAML.load_file(".github/workflows/release.yml")'
- git diff --check
- go build ./...
- docker build -t ensemble-tap:test .
