### PR TITLE
[codex] Harden Siphon CI quality gates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+    reviewers:
+      - evalops/engineering
+    commit-message:
+      prefix: "chore(deps):"
+    groups:
+      evalops-internal:
+        patterns:
+          - "github.com/evalops/*"
+        update-types:
+          - minor
+          - patch
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - ci
+    commit-message:
+      prefix: "chore(ci):"
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: monthly
+    labels:
+      - infrastructure
+    commit-message:
+      prefix: "chore(docker):"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -499,7 +499,9 @@ jobs:
   create-failure-issue:
     if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/main' && contains(needs.*.result, 'failure') }}
     needs:
+      - proto-lint
       - test
+      - golangci-lint
       - staticcheck
       - openapi-contract
       - config-lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,27 @@ env:
   GOTOOLCHAIN: go1.26.2
   TOOLS_BIN: ${{ github.workspace }}/.cache/tools/bin
   DISABLE_TOOL_CACHE: ${{ github.event_name == 'schedule' && 'true' || 'false' }}
+  GOLANGCI_LINT_VERSION: v2.11.3
   STATICCHECK_VERSION: v0.6.1
   GOSEC_VERSION: v2.23.0
   GOVULNCHECK_VERSION: v1.1.4
 
 jobs:
+  proto-lint:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Buf
+        uses: bufbuild/buf-action@v1
+        with:
+          setup_only: true
+
+      - name: Run buf lint
+        run: buf lint
+
   test:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 20
@@ -37,6 +53,9 @@ jobs:
 
       - name: Vet
         run: go vet ./...
+
+      - name: Race tests
+        run: go test ./... -race -count=1
 
       - name: Coverage
         env:
@@ -59,6 +78,25 @@ jobs:
         with:
           name: coverage-profile
           path: coverage.out
+
+  golangci-lint:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: evalops/service-runtime/.github/actions/setup-go-service@d348819979602be3a2b8349b5dccd41488bb7cd2
+        with:
+          go-version: "1.26.2"
+          download: "false"
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: ${{ env.GOLANGCI_LINT_VERSION }}
+          args: --timeout=5m ./...
 
   staticcheck:
     runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,12 @@
+version: "2"
+
+run:
+  timeout: 5m
+
+linters:
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,12 @@ GO ?= go
 MIN_COVERAGE ?= 75
 STATICCHECK_VERSION ?= v0.6.1
 STATICCHECK_BIN := $(shell $(GO) env GOPATH)/bin/staticcheck
+GOLANGCI_LINT_VERSION ?= v2.11.3
+GOLANGCI_LINT_BIN := $(shell $(GO) env GOPATH)/bin/golangci-lint
 
-.PHONY: ci-local test race vet staticcheck staticcheck-install coverage openapi proto config-lint chart-assert helm-lint helm-template onboard onboard-smoke setup-hooks install-hooks proto-check
+.PHONY: ci-local test race vet lint lint-install staticcheck staticcheck-install coverage openapi proto proto-lint config-lint chart-assert helm-lint helm-template onboard onboard-smoke setup-hooks install-hooks proto-check
 
-ci-local: vet test race staticcheck coverage openapi config-lint chart-assert helm-lint helm-template
+ci-local: vet test race lint staticcheck coverage openapi proto-lint config-lint chart-assert helm-lint helm-template
 
 test:
 	$(GO) test ./...
@@ -15,6 +17,12 @@ race:
 
 vet:
 	$(GO) vet ./...
+
+lint-install:
+	GOTOOLCHAIN=go1.26.2 $(GO) install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+
+lint: lint-install
+	GOTOOLCHAIN=go1.26.2 $(GOLANGCI_LINT_BIN) run ./...
 
 staticcheck-install:
 	GOTOOLCHAIN=go1.26.2 $(GO) install honnef.co/go/tools/cmd/staticcheck@$(STATICCHECK_VERSION)
@@ -38,6 +46,9 @@ openapi:
 
 proto:
 	buf generate
+
+proto-lint:
+	buf lint
 
 proto-check: proto
 	@if git diff --quiet -- 'proto/**/*.pb.go' 'proto/**/*connect.go'; then \

--- a/charts/siphon/README.md
+++ b/charts/siphon/README.md
@@ -189,6 +189,7 @@ Auth notes:
 ## Ops hardening defaults
 
 - `podDisruptionBudget.enabled=true` with `minAvailable=1`.
+- `startupProbe.enabled=true` on `/livez` to protect cold starts before liveness enforcement begins.
 - `serviceAccount.automount=false` to avoid mounting API tokens unless explicitly needed.
 - `networkPolicy.enabled=true` with explicit ingress/egress policy stanzas (DNS + HTTPS defaults).
 - `networkPolicy.allowConfigPorts=true` auto-derives NATS/ClickHouse TCP egress ports from `config.nats.url` and `config.clickhouse.addr`.

--- a/charts/siphon/templates/deployment.yaml
+++ b/charts/siphon/templates/deployment.yaml
@@ -59,6 +59,15 @@ spec:
               port: http
             initialDelaySeconds: 5
             periodSeconds: 5
+          {{- if .Values.startupProbe.enabled }}
+          startupProbe:
+            httpGet:
+              path: {{ .Values.startupProbe.path }}
+              port: http
+            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
+          {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           {{- if .Values.envFromSecret }}

--- a/charts/siphon/values.schema.json
+++ b/charts/siphon/values.schema.json
@@ -821,6 +821,31 @@
         }
       }
     },
+    "startupProbe": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "failureThreshold": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "periodSeconds": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "minimum": 1
+        }
+      },
+      "additionalProperties": false
+    },
     "envSecrets": {
       "type": "array",
       "items": {

--- a/charts/siphon/values.yaml
+++ b/charts/siphon/values.yaml
@@ -37,6 +37,13 @@ service:
   type: ClusterIP
   port: 8080
 
+startupProbe:
+  enabled: true
+  path: /livez
+  failureThreshold: 30
+  periodSeconds: 5
+  timeoutSeconds: 1
+
 ingress:
   enabled: false
   className: ""

--- a/cmd/tap/admin_replay_store_sqlite.go
+++ b/cmd/tap/admin_replay_store_sqlite.go
@@ -176,7 +176,9 @@ FROM admin_replay_jobs`)
 	if err != nil {
 		return nil, fmt.Errorf("query admin replay jobs: %w", err)
 	}
-	defer rows.Close()
+	defer func() {
+		_ = rows.Close()
+	}()
 
 	out := make([]*adminReplayJob, 0)
 	for rows.Next() {

--- a/cmd/tap/poller_config_test.go
+++ b/cmd/tap/poller_config_test.go
@@ -76,7 +76,9 @@ func TestOpenPollStores(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open sqlite stores: %v", err)
 	}
-	defer closer2.Close()
+	defer func() {
+		_ = closer2.Close()
+	}()
 	if err := cp2.Set("hubspot", "cp2"); err != nil {
 		t.Fatalf("set sqlite checkpoint: %v", err)
 	}

--- a/cmd/tap/run.go
+++ b/cmd/tap/run.go
@@ -101,7 +101,9 @@ func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
 		return err
 	}
 	if storesCloser != nil {
-		defer storesCloser.Close()
+		defer func() {
+			_ = storesCloser.Close()
+		}()
 	}
 
 	dlqPublisher, err := dlq.NewPublisher(ctx, cfg.NATS, publisher.JetStream())
@@ -140,7 +142,9 @@ func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
 		return err
 	}
 	if adminCloser != nil {
-		defer adminCloser.Close()
+		defer func() {
+			_ = adminCloser.Close()
+		}()
 	}
 
 	httpServer := ingressServer.HTTPServer(mux)

--- a/cmd/tap/run_test.go
+++ b/cmd/tap/run_test.go
@@ -1944,7 +1944,9 @@ func fetchMetricsBody(t *testing.T, url string) string {
 	if err != nil {
 		t.Fatalf("fetch metrics: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("expected metrics status 200, got %d", resp.StatusCode)
 	}
@@ -2069,7 +2071,9 @@ func freePort(t *testing.T) int {
 	if err != nil {
 		t.Fatalf("allocate port: %v", err)
 	}
-	defer ln.Close()
+	defer func() {
+		_ = ln.Close()
+	}()
 	return ln.Addr().(*net.TCPAddr).Port
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -976,7 +976,9 @@ func Load(path string) (Config, error) {
 		if err != nil {
 			return Config{}, fmt.Errorf("create temp config: %w", err)
 		}
-		defer os.Remove(tmpFile.Name())
+		defer func() {
+			_ = os.Remove(tmpFile.Name())
+		}()
 		if _, err := tmpFile.WriteString(expanded); err != nil {
 			return Config{}, fmt.Errorf("write temp config: %w", err)
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -976,8 +976,8 @@ func Load(path string) (Config, error) {
 		if err != nil {
 			return Config{}, fmt.Errorf("create temp config: %w", err)
 		}
-		// #nosec G703 -- tmpFile is created by os.CreateTemp above and removed in-process.
 		defer func() {
+			// #nosec G703 -- tmpFile.Name() comes from os.CreateTemp in this function.
 			_ = os.Remove(tmpFile.Name())
 		}()
 		if _, err := tmpFile.WriteString(expanded); err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -976,6 +976,7 @@ func Load(path string) (Config, error) {
 		if err != nil {
 			return Config{}, fmt.Errorf("create temp config: %w", err)
 		}
+		// #nosec G703 -- tmpFile is created by os.CreateTemp above and removed in-process.
 		defer func() {
 			_ = os.Remove(tmpFile.Name())
 		}()

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -238,8 +238,8 @@ func TestLoadConfigResolvesVaultReferencesWithKubernetesAuth(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		switch {
-		case r.URL.Path == "/v1/auth/kubernetes/login":
+		switch r.URL.Path {
+		case "/v1/auth/kubernetes/login":
 			loginCalls.Add(1)
 			var payload map[string]string
 			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
@@ -258,7 +258,7 @@ func TestLoadConfigResolvesVaultReferencesWithKubernetesAuth(t *testing.T) {
 					"client_token": "vault-runtime-token",
 				},
 			})
-		case r.URL.Path == "/v1/secret/data/homelab/siphon/runtime":
+		case "/v1/secret/data/homelab/siphon/runtime":
 			readCalls.Add(1)
 			if got := r.Header.Get("X-Vault-Token"); got != "vault-runtime-token" {
 				t.Errorf("unexpected vault token header: %q", got)
@@ -875,7 +875,7 @@ func TestConfigValidateNATSAndClickHouseRules(t *testing.T) {
 				NATS: NATSConfig{
 					URL:                "nats://localhost:4222",
 					Stream:             "SIPHON",
-					SubjectPrefix: "siphon.tap",
+					SubjectPrefix:      "siphon.tap",
 					InsecureSkipVerify: true,
 				},
 			},
@@ -900,7 +900,7 @@ func TestConfigValidateNATSAndClickHouseRules(t *testing.T) {
 				NATS: NATSConfig{
 					URL:              "nats://localhost:4222",
 					Stream:           "SIPHON",
-					SubjectPrefix: "siphon.tap",
+					SubjectPrefix:    "siphon.tap",
 					StreamMaxMsgSize: 2147483648,
 				},
 			},
@@ -1108,7 +1108,7 @@ func TestConfigValidateNATSAndClickHouseRules(t *testing.T) {
 				NATS: NATSConfig{
 					URL:                 "nats://localhost:4222",
 					Stream:              "SIPHON",
-					SubjectPrefix: "siphon.tap",
+					SubjectPrefix:       "siphon.tap",
 					MaxAge:              24 * time.Hour,
 					DedupWindow:         time.Minute,
 					ConnectTimeout:      5 * time.Second,
@@ -1310,7 +1310,7 @@ func TestConfigValidateAdvancedNATSAndClickHouseControls(t *testing.T) {
 			NATS: NATSConfig{
 				URL:                 "nats://localhost:4222",
 				Stream:              "SIPHON",
-				SubjectPrefix: "siphon.tap",
+				SubjectPrefix:       "siphon.tap",
 				MaxAge:              24 * time.Hour,
 				DedupWindow:         time.Minute,
 				ConnectTimeout:      5 * time.Second,

--- a/config/vault_refs.go
+++ b/config/vault_refs.go
@@ -274,12 +274,16 @@ func readFileWithinRoot(rawPath string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open path root %q: %w", rootPath, err)
 	}
-	defer root.Close()
+	defer func() {
+		_ = root.Close()
+	}()
 
 	file, err := root.Open(fileName)
 	if err != nil {
 		return nil, fmt.Errorf("open file %q: %w", path, err)
 	}
-	defer file.Close()
+	defer func() {
+		_ = file.Close()
+	}()
 	return io.ReadAll(file)
 }

--- a/internal/ingress/providers/github.go
+++ b/internal/ingress/providers/github.go
@@ -28,9 +28,9 @@ func (h GitHubHandler) Handle(r *http.Request, _ []byte, cfg cfgpkg.ProviderConf
 		return WebhookEvent{}, fmt.Errorf("missing X-GitHub-Event header")
 	}
 
-	if _, err := gh.ParseWebHook(eventType, payload); err != nil {
-		// We still process unknown payloads as generic GitHub events.
-	}
+	// Parse the payload when GitHub exposes a typed event, but still allow
+	// generic normalization for unknown event shapes.
+	_, _ = gh.ParseWebHook(eventType, payload)
 
 	deliveryID := r.Header.Get("X-GitHub-Delivery")
 	normEvt, err := norm.NormalizeGitHub(eventType, deliveryID, cfg.TenantID, payload)

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -37,7 +37,9 @@ func TestSQLiteStateStoreCheckpointAndSnapshotPersistence(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reopen sqlite store: %v", err)
 	}
-	defer reopen.Close()
+	defer func() {
+		_ = reopen.Close()
+	}()
 
 	cp2, ok := reopen.Checkpoints.Get("hubspot")
 	if !ok || cp2 != "cp_1" {

--- a/scripts/assert-chart-render.sh
+++ b/scripts/assert-chart-render.sh
@@ -25,9 +25,10 @@ cd "${ROOT}"
 rendered_default="$(mktemp)"
 rendered_fixture="$(mktemp)"
 rendered_automount="$(mktemp)"
+rendered_startup_disabled="$(mktemp)"
 fixture_values="$(mktemp)"
 cleanup() {
-  rm -f "${rendered_default}" "${rendered_fixture}" "${rendered_automount}" "${fixture_values}"
+  rm -f "${rendered_default}" "${rendered_fixture}" "${rendered_automount}" "${rendered_startup_disabled}" "${fixture_values}"
 }
 trap cleanup EXIT
 
@@ -63,6 +64,7 @@ EOF
 helm template siphon charts/siphon >"${rendered_default}"
 helm template siphon charts/siphon -f "${fixture_values}" >"${rendered_fixture}"
 helm template siphon charts/siphon --set serviceAccount.automount=true >"${rendered_automount}"
+helm template siphon charts/siphon --set startupProbe.enabled=false >"${rendered_startup_disabled}"
 
 default_automount="$(yq -r 'select(.kind == "Deployment") | .spec.template.spec.automountServiceAccountToken' "${rendered_default}")"
 [[ "${default_automount}" == "false" ]] || fail "default automountServiceAccountToken should be false, got ${default_automount}"
@@ -84,5 +86,11 @@ nats_scope="$(yq -r 'select(.kind == "NetworkPolicy") | .spec.egress[] | select(
 
 clickhouse_scope="$(yq -r 'select(.kind == "NetworkPolicy") | .spec.egress[] | select(.ports[]?.port == 9000) | .to[0].ipBlock.cidr' "${rendered_fixture}")"
 [[ "${clickhouse_scope}" == "10.42.0.0/16" ]] || fail "expected ClickHouse scoped ipBlock.cidr to render, got ${clickhouse_scope}"
+
+startup_path="$(yq -r 'select(.kind == "Deployment") | .spec.template.spec.containers[] | select(.name == "tap") | .startupProbe.httpGet.path' "${rendered_default}")"
+[[ "${startup_path}" == "/livez" ]] || fail "default startupProbe path should be /livez, got ${startup_path}"
+
+startup_disabled="$(yq -r 'select(.kind == "Deployment") | .spec.template.spec.containers[] | select(.name == "tap") | has("startupProbe")' "${rendered_startup_disabled}")"
+[[ "${startup_disabled}" == "false" ]] || fail "startupProbe should be omitted when startupProbe.enabled=false, got ${startup_disabled}"
 
 echo "ok: chart render assertions passed"


### PR DESCRIPTION
## Summary
- add missing CI gates for `buf lint`, `golangci-lint`, and race-enabled test execution
- add repo-local `dependabot.yml`, `golangci-lint`/`buf lint` Make targets, and fix the code issues the new lint job surfaced
- add configurable Helm `startupProbe` support plus schema/render assertions and chart docs

## Validation
- `GOTOOLCHAIN=go1.26.2 go test ./... -count=1`
- `GOTOOLCHAIN=go1.26.2 go test ./... -race -count=1`
- `GOTOOLCHAIN=go1.26.2 go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.3 run ./...`
- `buf lint`
- `./scripts/assert-chart-render.sh`
- `helm lint charts/siphon && helm template siphon charts/siphon >/dev/null`

## Notes
- `actionlint` in this local environment reports the repo's existing custom `blacksmith-4vcpu-ubuntu-2404` runner label as unknown, so I used it as a syntax/shellcheck spot check rather than a strict pass/fail gate.

Closes #20