### PR TITLE
ci: notify platform monorepo on push to main

### DIFF
--- a/.github/workflows/notify-platform.yml
+++ b/.github/workflows/notify-platform.yml
@@ -1,0 +1,24 @@
+name: Notify Platform Monorepo
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    steps:
+      - name: Dispatch sync to platform
+        env:
+          GH_TOKEN: ${{ secrets.ADMIN_CONTROL_PLANE_SYNC_TOKEN || secrets.GH_BOT_TOKEN || secrets.PAT || github.token }}
+        run: |
+          service="${GITHUB_REPOSITORY#*/}"
+          gh api repos/evalops/platform/dispatches \
+            -X POST \
+            -f event_type="upstream-service-push" \
+            -f "client_payload[service]=${service}" \
+            -f "client_payload[source_sha]=${GITHUB_SHA}" \
+            -f "client_payload[source_ref]=${GITHUB_REF_NAME}"

--- a/.github/workflows/notify-platform.yml
+++ b/.github/workflows/notify-platform.yml
@@ -9,17 +9,16 @@ permissions:
 
 jobs:
   dispatch:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Dispatch sync to platform
         env:
           GH_TOKEN: ${{ secrets.ADMIN_CONTROL_PLANE_SYNC_TOKEN || secrets.GH_BOT_TOKEN || secrets.PAT }}
         run: |
-          if [ -z "${GH_TOKEN}" ]; then
-            echo "::error::Set ADMIN_CONTROL_PLANE_SYNC_TOKEN, GH_BOT_TOKEN, or PAT to dispatch to evalops/platform."
+          if [[ -z "${GH_TOKEN}" ]]; then
+            echo "::error::No cross-repo token configured. Set ADMIN_CONTROL_PLANE_SYNC_TOKEN, GH_BOT_TOKEN, or PAT in repo secrets."
             exit 1
           fi
-
           service="${GITHUB_REPOSITORY#*/}"
           gh api repos/evalops/platform/dispatches \
             -X POST \

--- a/.github/workflows/notify-platform.yml
+++ b/.github/workflows/notify-platform.yml
@@ -13,8 +13,13 @@ jobs:
     steps:
       - name: Dispatch sync to platform
         env:
-          GH_TOKEN: ${{ secrets.ADMIN_CONTROL_PLANE_SYNC_TOKEN || secrets.GH_BOT_TOKEN || secrets.PAT || github.token }}
+          GH_TOKEN: ${{ secrets.ADMIN_CONTROL_PLANE_SYNC_TOKEN || secrets.GH_BOT_TOKEN || secrets.PAT }}
         run: |
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "::error::Set ADMIN_CONTROL_PLANE_SYNC_TOKEN, GH_BOT_TOKEN, or PAT to dispatch to evalops/platform."
+            exit 1
+          fi
+
           service="${GITHUB_REPOSITORY#*/}"
           gh api repos/evalops/platform/dispatches \
             -X POST \


### PR DESCRIPTION
Dispatches a repository_dispatch event to evalops/platform when this repo pushes to main, triggering the automated crossover sync workflow to keep _import/ mirrors up to date.

See evalops/platform#80 for the receiving workflow.
See evalops/platform#65 for the drift tracking issue.